### PR TITLE
feat: complete node grouping with visual indicators and clustering

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -365,6 +365,12 @@ impl eframe::App for NeuronicApp {
                     ui.add_space(16.0);
                     panels::draw_legend(ui, &self.theme);
                 }
+
+                // Show group legend if groups exist
+                if !self.node_groups.is_empty() {
+                    ui.add_space(16.0);
+                    panels::draw_group_legend(ui, &self.node_groups);
+                }
             });
 
         // Left panel for filters/groups if open
@@ -422,6 +428,7 @@ impl eframe::App for NeuronicApp {
                 &mut self.node_positions,
                 &mut self.node_velocities,
                 rect,
+                &self.node_groups,
             );
 
             // Focus on highlighted node
@@ -444,6 +451,7 @@ impl eframe::App for NeuronicApp {
                 activity: &self.node_activity,
                 particles: &self.synapse_particles,
                 pulse_rings: &self.pulse_rings,
+                node_groups: &self.node_groups,
                 selected_node: self.selected_node.as_ref(),
                 highlighted_node: self.highlighted_node.as_ref(),
                 theme: &self.theme,

--- a/src/ui/drawing.rs
+++ b/src/ui/drawing.rs
@@ -8,7 +8,7 @@ use egui::{Color32, Pos2, Rect, Stroke, Vec2};
 use std::collections::HashMap;
 
 use super::theme::Theme;
-use super::types::{NodeActivity, PulseRing, SynapseParticle};
+use super::types::{NodeActivity, NodeGroup, PulseRing, SynapseParticle};
 
 /// Calculate a point on a quadratic Bezier curve.
 ///
@@ -145,6 +145,7 @@ pub struct DrawContext<'a> {
     pub activity: &'a HashMap<String, NodeActivity>,
     pub particles: &'a HashMap<(String, String, String), Vec<SynapseParticle>>,
     pub pulse_rings: &'a HashMap<String, Vec<PulseRing>>,
+    pub node_groups: &'a [NodeGroup],
     pub selected_node: Option<&'a String>,
     pub highlighted_node: Option<&'a String>,
     pub theme: &'a Theme,
@@ -358,6 +359,19 @@ impl<'a> DrawContext<'a> {
             // Inner highlight (nucleus)
             let nucleus_color = lerp_color(color, Color32::WHITE, 0.3);
             painter.circle_filled(pos, radius * 0.4, nucleus_color);
+
+            // Group color ring (drawn before selection ring)
+            for (group_idx, group) in self.node_groups.iter().enumerate() {
+                if !group.collapsed && group.nodes.contains(&node.name) {
+                    let group_color = super::types::get_group_color(group_idx);
+                    painter.circle_stroke(
+                        pos,
+                        radius + 6.0 * self.zoom,
+                        Stroke::new(3.0 * self.zoom, group_color),
+                    );
+                    break; // Only show first matching group
+                }
+            }
 
             // Selection/highlight ring
             if is_selected || is_highlighted {

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -10,7 +10,7 @@ use crate::graph::MessageFlowGraph;
 use egui::{Pos2, Rect, Vec2};
 use std::collections::HashMap;
 
-use super::types::LayoutMode;
+use super::types::{LayoutMode, NodeGroup};
 
 /// Apply force-directed layout to node positions.
 ///
@@ -26,6 +26,7 @@ pub fn apply_force_directed(
     positions: &mut HashMap<String, Pos2>,
     velocities: &mut HashMap<String, Vec2>,
     rect: Rect,
+    groups: &[NodeGroup],
 ) {
     let center = rect.center();
     let node_count = graph.module_count();
@@ -94,6 +95,37 @@ pub fn apply_force_directed(
                 let force = delta.normalized() * (dist - min_distance) * attraction;
                 *forces.get_mut(&source_node.name).unwrap() += force;
                 *forces.get_mut(&target_node.name).unwrap() -= force;
+            }
+        }
+    }
+
+    // Group attraction - nodes in same group attract each other
+    let group_attraction = 0.001;
+    for group in groups {
+        if group.collapsed {
+            continue; // Don't apply forces for collapsed groups
+        }
+        for i in 0..group.nodes.len() {
+            for j in (i + 1)..group.nodes.len() {
+                let name_i = &group.nodes[i];
+                let name_j = &group.nodes[j];
+
+                if let (Some(&pos_i), Some(&pos_j)) = (positions.get(name_i), positions.get(name_j))
+                {
+                    let delta = pos_j - pos_i;
+                    let dist = delta.length();
+
+                    if dist > min_distance * 0.5 {
+                        let force =
+                            delta.normalized() * (dist - min_distance * 0.5) * group_attraction;
+                        if let Some(f) = forces.get_mut(name_i) {
+                            *f += force;
+                        }
+                        if let Some(f) = forces.get_mut(name_j) {
+                            *f -= force;
+                        }
+                    }
+                }
             }
         }
     }
@@ -201,9 +233,12 @@ pub fn apply_layout(
     positions: &mut HashMap<String, Pos2>,
     velocities: &mut HashMap<String, Vec2>,
     rect: Rect,
+    groups: &[NodeGroup],
 ) {
     match mode {
-        LayoutMode::ForceDirected => apply_force_directed(graph, positions, velocities, rect),
+        LayoutMode::ForceDirected => {
+            apply_force_directed(graph, positions, velocities, rect, groups)
+        }
         LayoutMode::Hierarchical => apply_hierarchical(graph, positions, rect),
     }
 }
@@ -224,7 +259,7 @@ mod tests {
         let mut velocities = HashMap::new();
         let rect = create_test_rect();
 
-        apply_force_directed(&graph, &mut positions, &mut velocities, rect);
+        apply_force_directed(&graph, &mut positions, &mut velocities, rect, &[]);
 
         assert!(positions.is_empty());
         assert!(velocities.is_empty());
@@ -243,7 +278,7 @@ mod tests {
         let mut velocities = HashMap::new();
         let rect = create_test_rect();
 
-        apply_force_directed(&graph, &mut positions, &mut velocities, rect);
+        apply_force_directed(&graph, &mut positions, &mut velocities, rect, &[]);
 
         // Should have positions for both nodes
         assert_eq!(positions.len(), 2);
@@ -274,7 +309,7 @@ mod tests {
 
         let original_pos = positions["node1"];
 
-        apply_force_directed(&graph, &mut positions, &mut velocities, rect);
+        apply_force_directed(&graph, &mut positions, &mut velocities, rect, &[]);
 
         // Position should have changed due to center gravity, but not be reinitialized
         // (it should still exist and be near the original)
@@ -307,7 +342,7 @@ mod tests {
 
         // Run several iterations
         for _ in 0..10 {
-            apply_force_directed(&graph, &mut positions, &mut velocities, rect);
+            apply_force_directed(&graph, &mut positions, &mut velocities, rect, &[]);
         }
 
         // Nodes should have moved apart
@@ -463,6 +498,7 @@ mod tests {
             &mut positions,
             &mut velocities,
             rect,
+            &[],
         );
         assert!(positions.contains_key("node1"));
         assert!(velocities.contains_key("node1"));
@@ -476,6 +512,7 @@ mod tests {
             &mut positions,
             &mut velocities,
             rect,
+            &[],
         );
         assert!(positions.contains_key("node1"));
     }

--- a/src/ui/panels.rs
+++ b/src/ui/panels.rs
@@ -11,7 +11,7 @@ use crate::graph::{HealthStatus, MessageFlowGraph};
 use egui::{Color32, Vec2};
 
 use super::theme::Theme;
-use super::types::{NodeActivity, NodeGroup};
+use super::types::{get_group_color, NodeActivity, NodeGroup};
 
 /// Draw the details panel showing information about the selected node.
 ///
@@ -110,6 +110,31 @@ fn draw_legend_item(ui: &mut egui::Ui, color: Color32, label: &str) {
     });
 }
 
+/// Draw a legend for active node groups.
+pub fn draw_group_legend(ui: &mut egui::Ui, groups: &[NodeGroup]) {
+    if groups.is_empty() {
+        return;
+    }
+
+    ui.heading("Groups");
+    ui.separator();
+
+    for (idx, group) in groups.iter().enumerate() {
+        let color = get_group_color(idx);
+        ui.horizontal(|ui| {
+            let (rect, _) = ui.allocate_exact_size(Vec2::new(16.0, 16.0), egui::Sense::hover());
+            ui.painter()
+                .circle_stroke(rect.center(), 7.0, egui::Stroke::new(2.0, color));
+            let status = if group.collapsed {
+                format!("{} (collapsed)", group.name)
+            } else {
+                format!("{} ({})", group.name, group.nodes.len())
+            };
+            ui.label(status);
+        });
+    }
+}
+
 /// Draw the topic filter panel for hiding noisy topics.
 ///
 /// Returns `true` if filters were modified, indicating the graph
@@ -204,12 +229,13 @@ pub fn draw_group_panel(
                 .collect();
 
             if !nodes.is_empty() {
+                let color = get_group_color(groups.len());
                 groups.push(NodeGroup {
                     name: format!("*{}", pattern),
                     pattern: pattern.clone(),
                     nodes,
                     collapsed: false,
-                    color: Color32::from_rgb(100, 150, 200),
+                    color,
                 });
             }
             new_pattern.clear();

--- a/src/ui/types.rs
+++ b/src/ui/types.rs
@@ -46,11 +46,27 @@ pub struct PulseRing {
 
 /// Node group for clustering.
 #[derive(Clone)]
-#[allow(dead_code)]
 pub struct NodeGroup {
     pub name: String,
     pub pattern: String,
     pub nodes: Vec<String>,
     pub collapsed: bool,
     pub color: Color32,
+}
+
+/// Predefined color palette for node groups.
+pub const GROUP_COLORS: [Color32; 8] = [
+    Color32::from_rgb(70, 130, 180),  // Steel blue
+    Color32::from_rgb(144, 238, 144), // Light green
+    Color32::from_rgb(255, 182, 193), // Light pink
+    Color32::from_rgb(255, 218, 185), // Peach
+    Color32::from_rgb(221, 160, 221), // Plum
+    Color32::from_rgb(176, 224, 230), // Powder blue
+    Color32::from_rgb(255, 255, 150), // Light yellow
+    Color32::from_rgb(230, 230, 250), // Lavender
+];
+
+/// Get a color for a group by index.
+pub fn get_group_color(index: usize) -> Color32 {
+    GROUP_COLORS[index % GROUP_COLORS.len()]
 }


### PR DESCRIPTION
## Summary
Complete the node grouping feature with visual clustering and a group legend.

## Changes

### Visual Indicators
- **Color palette**: Added 8 distinct colors for groups (steel blue, light green, pink, peach, plum, powder blue, yellow, lavender)
- **Group rings**: Nodes in a group display a colored ring around them
- **Group legend**: Right panel shows active groups with their colors and node counts

### Layout Clustering  
- **Group attraction force**: Nodes in the same group attract each other slightly in force-directed layout
- Groups that are collapsed don't apply attraction forces

### Group Management
- Groups use palette colors automatically when created
- Groups can be collapsed/expanded via the group panel
- Collapsed groups show "(collapsed)" in the legend

## Files Changed
- `src/ui/types.rs`: Added GROUP_COLORS palette and get_group_color() function
- `src/ui/drawing.rs`: Added group ring rendering around nodes
- `src/ui/layout.rs`: Added group attraction force to force-directed layout
- `src/ui/panels.rs`: Added draw_group_legend() function, updated group creation to use palette
- `src/ui/app.rs`: Pass groups to layout and DrawContext, show group legend

## Testing
- All 90 existing tests pass
- Layout tests updated to pass groups parameter

Closes #21