### PR TITLE
[feat] fix stale graph nodes and minimap viewport mapping

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -7,7 +7,7 @@ use buswatch_types::Snapshot;
 use petgraph::algo::tarjan_scc;
 use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 /// Key for identifying an edge (source module, target module, topic).
@@ -179,6 +179,14 @@ impl RateTracker {
     fn elapsed_secs(&self, now: Instant) -> Option<f64> {
         self.prev_time.map(|t| now.duration_since(t).as_secs_f64())
     }
+
+    /// Remove tracked edge state for modules no longer present in the graph.
+    fn prune_stale_modules(&mut self, active_modules: &HashSet<String>) {
+        self.prev_counts
+            .retain(|(source, target, _), _| active_modules.contains(source) && active_modules.contains(target));
+        self.smoothed_rates
+            .retain(|(source, target, _), _| active_modules.contains(source) && active_modules.contains(target));
+    }
 }
 
 /// The message flow graph.
@@ -245,6 +253,9 @@ impl MessageFlowGraph {
         self.last_update_ms = snapshot.timestamp_ms;
         let now = Instant::now();
         let elapsed_secs = self.rate_tracker.elapsed_secs(now);
+        let mut graph = DiGraph::new();
+        let mut module_indices = HashMap::new();
+        let active_modules: HashSet<String> = snapshot.iter().map(|(name, _)| name.clone()).collect();
 
         // First pass: create/update all module nodes
         for (module_name, metrics) in snapshot.iter() {
@@ -287,38 +298,27 @@ impl MessageFlowGraph {
                 write_topics,
             };
 
-            if let Some(&idx) = self.module_indices.get(module_name) {
-                // Update existing node
-                self.graph[idx] = node;
-            } else {
-                // Add new node
-                let idx = self.graph.add_node(node);
-                self.module_indices.insert(module_name.clone(), idx);
-            }
+            let idx = graph.add_node(node);
+            module_indices.insert(module_name.clone(), idx);
         }
-
-        // Clear existing edges (we rebuild them each update)
-        self.graph.clear_edges();
 
         // Second pass: create edges based on topic connections
         // For each topic, connect producers to consumers
-        let mut topic_producers: HashMap<String, Vec<(NodeIndex, u64, Option<f64>)>> =
+        let mut topic_producers: HashMap<String, Vec<(String, u64, Option<f64>)>> =
             HashMap::new();
         #[allow(clippy::type_complexity)]
         let mut topic_consumers: HashMap<
             String,
-            Vec<(NodeIndex, u64, Option<u64>, Option<u64>, Option<f64>)>,
+            Vec<(String, u64, Option<u64>, Option<u64>, Option<f64>)>,
         > = HashMap::new();
 
         for (module_name, metrics) in snapshot.iter() {
-            let idx = self.module_indices[module_name];
-
             for (topic, write_metrics) in &metrics.writes {
                 if self.should_ignore_topic(topic) {
                     continue;
                 }
                 topic_producers.entry(topic.clone()).or_default().push((
-                    idx,
+                    module_name.clone(),
                     write_metrics.count,
                     write_metrics.rate,
                 ));
@@ -329,7 +329,7 @@ impl MessageFlowGraph {
                     continue;
                 }
                 topic_consumers.entry(topic.clone()).or_default().push((
-                    idx,
+                    module_name.clone(),
                     read_metrics.count,
                     read_metrics.backlog,
                     read_metrics.pending.map(|p| p.as_micros()),
@@ -341,16 +341,25 @@ impl MessageFlowGraph {
         // Create edges from producers to consumers
         for (topic, producers) in &topic_producers {
             if let Some(consumers) = topic_consumers.get(topic) {
-                for &(producer_idx, write_count, write_rate) in producers {
-                    for &(consumer_idx, read_count, backlog, pending_us, read_rate) in consumers {
-                        let health = self.compute_edge_health(backlog, pending_us);
-                        let message_count = write_count.max(read_count);
+                for (producer_name, write_count, write_rate) in producers {
+                    for (consumer_name, read_count, backlog, pending_us, read_rate) in consumers {
+                        let Some(&producer_idx) = module_indices.get(producer_name) else {
+                            continue;
+                        };
+                        let Some(&consumer_idx) = module_indices.get(consumer_name) else {
+                            continue;
+                        };
+
+                        let health = self.compute_edge_health(*backlog, *pending_us);
+                        let message_count = (*write_count).max(*read_count);
 
                         // Use provided rate, or infer from count delta with smoothing
-                        let rate = write_rate.or(read_rate).or_else(|| {
-                            let source_name = &self.graph[producer_idx].name;
-                            let target_name = &self.graph[consumer_idx].name;
-                            let key = (source_name.clone(), target_name.clone(), topic.clone());
+                        let rate = (*write_rate).or(*read_rate).or_else(|| {
+                            let key = (
+                                producer_name.clone(),
+                                consumer_name.clone(),
+                                topic.clone(),
+                            );
                             self.rate_tracker
                                 .calculate_rate(key, message_count, elapsed_secs)
                         });
@@ -359,16 +368,19 @@ impl MessageFlowGraph {
                             topic: topic.clone(),
                             message_count,
                             rate,
-                            backlog,
-                            pending_us,
+                            backlog: *backlog,
+                            pending_us: *pending_us,
                             health,
                         };
-                        self.graph.add_edge(producer_idx, consumer_idx, edge);
+                        graph.add_edge(producer_idx, consumer_idx, edge);
                     }
                 }
             }
         }
 
+        self.rate_tracker.prune_stale_modules(&active_modules);
+        self.graph = graph;
+        self.module_indices = module_indices;
         self.rate_tracker.mark_snapshot_time(now);
     }
 
@@ -544,6 +556,28 @@ mod tests {
 
         assert_eq!(graph.module_count(), 2);
         assert_eq!(graph.edge_count(), 1); // producer -> consumer via "events"
+    }
+
+    #[test]
+    fn test_modules_removed_when_missing_from_new_snapshot() {
+        let mut graph = MessageFlowGraph::new();
+
+        let initial = Snapshot::builder()
+            .timestamp_ms(1000)
+            .module("producer", |m| m.write("events", |w| w.count(100)))
+            .module("consumer", |m| m.read("events", |r| r.count(95).backlog(5)))
+            .build();
+        graph.update_from_snapshot(&initial);
+
+        let updated = Snapshot::builder()
+            .timestamp_ms(2000)
+            .module("consumer", |m| m.read("events", |r| r.count(96).backlog(4)))
+            .build();
+        graph.update_from_snapshot(&updated);
+
+        assert_eq!(graph.module_count(), 1);
+        assert!(graph.module_indices.contains_key("consumer"));
+        assert!(!graph.module_indices.contains_key("producer"));
     }
 
     #[test]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -182,10 +182,12 @@ impl RateTracker {
 
     /// Remove tracked edge state for modules no longer present in the graph.
     fn prune_stale_modules(&mut self, active_modules: &HashSet<String>) {
-        self.prev_counts
-            .retain(|(source, target, _), _| active_modules.contains(source) && active_modules.contains(target));
-        self.smoothed_rates
-            .retain(|(source, target, _), _| active_modules.contains(source) && active_modules.contains(target));
+        self.prev_counts.retain(|(source, target, _), _| {
+            active_modules.contains(source) && active_modules.contains(target)
+        });
+        self.smoothed_rates.retain(|(source, target, _), _| {
+            active_modules.contains(source) && active_modules.contains(target)
+        });
     }
 }
 
@@ -255,7 +257,8 @@ impl MessageFlowGraph {
         let elapsed_secs = self.rate_tracker.elapsed_secs(now);
         let mut graph = DiGraph::new();
         let mut module_indices = HashMap::new();
-        let active_modules: HashSet<String> = snapshot.iter().map(|(name, _)| name.clone()).collect();
+        let active_modules: HashSet<String> =
+            snapshot.iter().map(|(name, _)| name.clone()).collect();
 
         // First pass: create/update all module nodes
         for (module_name, metrics) in snapshot.iter() {
@@ -304,8 +307,7 @@ impl MessageFlowGraph {
 
         // Second pass: create edges based on topic connections
         // For each topic, connect producers to consumers
-        let mut topic_producers: HashMap<String, Vec<(String, u64, Option<f64>)>> =
-            HashMap::new();
+        let mut topic_producers: HashMap<String, Vec<(String, u64, Option<f64>)>> = HashMap::new();
         #[allow(clippy::type_complexity)]
         let mut topic_consumers: HashMap<
             String,
@@ -355,11 +357,7 @@ impl MessageFlowGraph {
 
                         // Use provided rate, or infer from count delta with smoothing
                         let rate = (*write_rate).or(*read_rate).or_else(|| {
-                            let key = (
-                                producer_name.clone(),
-                                consumer_name.clone(),
-                                topic.clone(),
-                            );
+                            let key = (producer_name.clone(), consumer_name.clone(), topic.clone());
                             self.rate_tracker
                                 .calculate_rate(key, message_count, elapsed_secs)
                         });

--- a/src/ui/drawing/minimap.rs
+++ b/src/ui/drawing/minimap.rs
@@ -77,8 +77,7 @@ pub fn draw_minimap(
     }
 
     // Draw viewport rectangle
-    let viewport_center = viewport_rect.center();
-    let viewport_world_center = Pos2::new(viewport_center.x - pan.x, viewport_center.y - pan.y);
+    let viewport_world_center = viewport_center_in_world(viewport_rect, zoom, pan);
 
     let viewport_world_size =
         Vec2::new(viewport_rect.width() / zoom, viewport_rect.height() / zoom);
@@ -100,4 +99,30 @@ pub fn draw_minimap(
         Stroke::new(1.0, Color32::WHITE.gamma_multiply(0.5)),
         egui::StrokeKind::Outside,
     );
+}
+
+fn viewport_center_in_world(viewport_rect: Rect, zoom: f32, pan: Vec2) -> Pos2 {
+    let viewport_center = viewport_rect.center();
+    let safe_zoom = zoom.max(f32::EPSILON);
+    Pos2::new(
+        viewport_center.x - pan.x / safe_zoom,
+        viewport_center.y - pan.y / safe_zoom,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_viewport_center_in_world_applies_zoom_to_pan() {
+        let rect = Rect::from_center_size(Pos2::new(400.0, 300.0), Vec2::new(800.0, 600.0));
+        let zoom = 2.0;
+        let pan = Vec2::new(100.0, 50.0);
+
+        let world_center = viewport_center_in_world(rect, zoom, pan);
+
+        assert!((world_center.x - 350.0).abs() < 0.001);
+        assert!((world_center.y - 275.0).abs() < 0.001);
+    }
 }


### PR DESCRIPTION
## Summary
This fixes two user-visible correctness issues in graph lifecycle and minimap viewport mapping.

When snapshots dropped modules, the graph retained stale nodes indefinitely. This caused the UI to display modules that no longer existed in the live stream and could also keep stale rate-tracker state around for removed node pairs.

Separately, the minimap viewport rectangle used an incorrect inverse transform from screen space to world space. The previous code subtracted pan directly without accounting for zoom, so the minimap rectangle drifted from the true viewport position whenever zoom was not `1.0`.

## Root Cause
The graph update path incrementally updated/added nodes but never removed missing ones, while edges were rebuilt each frame. That made node lifetime additive instead of snapshot-consistent.

The minimap conversion inverted `world_to_screen` incorrectly by omitting division by zoom in the pan term.

## Fix
- Reworked `MessageFlowGraph::update_from_snapshot` to rebuild a fresh graph/module index from each snapshot, ensuring only current modules exist.
- Added rate-tracker pruning for modules no longer present to avoid stale edge-rate memory.
- Corrected minimap viewport center conversion with `pan / zoom` and extracted a helper for focused testing.
- Added regression tests for:
  - Removing modules absent from subsequent snapshots.
  - Minimap viewport world-center mapping under non-unit zoom.

## Validation
- `cargo test` (all tests passing)
